### PR TITLE
feat: add `extra=allow` config / `model_extra` dicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ client = TmdsClient(tmds_config)
 netzvertrage = await client.get_netzvertraege_for_melo("DE1234567890123456789012345678901")
 ```
 
+Even though we did not fully replicate the TMDS data model (mainly [BO4E.net](https://github.com/Hochfrequenz/BO4E-dotnet/) + some wrapper classes),
+we tried to make the client as flexible as possible.
+You can use any unmapped field returned by TMDS by using the [`model_extra` property of pydantic](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_extra).
+
 ## Development
 For development of this library, follow the instructions in our [Python Template Repository](https://github.com/Hochfrequenz/python_template_repository).
 tl;dr: `tox -e dev` will set up a development environment for you.

--- a/src/tmdsclient/models/netzvertrag.py
+++ b/src/tmdsclient/models/netzvertrag.py
@@ -4,7 +4,7 @@ a Netzvertrag is a contract between a supplier and a grid operator
 
 from uuid import UUID
 
-from pydantic import AwareDatetime, BaseModel, Field, RootModel
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel
 
 
 class Bo4eVertrag(BaseModel):
@@ -12,6 +12,7 @@ class Bo4eVertrag(BaseModel):
     a bo4e vertrag (inside the Netzvertrag)
     """
 
+    model_config = ConfigDict(extra="allow")
     vertragsnummer: str
     vertragsbeginn: AwareDatetime
     vertragsende: AwareDatetime | None = None
@@ -22,6 +23,7 @@ class Netzvertrag(BaseModel):
     a TMDS netzvertrag
     """
 
+    model_config = ConfigDict(extra="allow")
     id: UUID
     bo_model: Bo4eVertrag | None = Field(alias="boModel", default=None)
 

--- a/unittests/test_get_netzvertraege.py
+++ b/unittests/test_get_netzvertraege.py
@@ -24,3 +24,5 @@ class TestGetNetzvertraege:
         assert isinstance(actual, list)
         assert all(isinstance(x, Netzvertrag) for x in actual)
         assert actual[0].bo_model.vertragsbeginn is not None
+        assert any(actual[0].model_extra), "Unmapped properties should be stored in model_extra (Netzvertrag)"
+        assert any(actual[0].bo_model.model_extra), "Unmapped properties should be stored in model_extra (Bo4eVertrag)"


### PR DESCRIPTION
to easily access unmapped properties without releasing a new version of this library