### PR TITLE
use `json=` instead of `data=` in PATCH request

### DIFF
--- a/src/tmdsclient/client/tmdsclient.py
+++ b/src/tmdsclient/client/tmdsclient.py
@@ -104,7 +104,7 @@ class TmdsClient:
         request_uuid = uuid.uuid4()
         _logger.debug("[%s] requesting %s", str(request_uuid), request_url)
         async with session.patch(
-            request_url, data=patch_document.patch, headers={"Content-Type": "application/json-patch+json"}
+            request_url, json=patch_document.patch, headers={"Content-Type": "application/json-patch+json"}
         ) as response:
             response.raise_for_status()
             _logger.debug("[%s] response status: %s", str(request_uuid), response.status)

--- a/unittests/test_netzvertraege.py
+++ b/unittests/test_netzvertraege.py
@@ -55,7 +55,7 @@ class TestGetNetzvertraege:
             nv.bo_model.vertragstatus = Vertragsstatus.STORNIERT
 
         def patch_endpoint_callback(url, **kwargs):  # pylint:disable=unused-argument
-            request_body = kwargs["data"]
+            request_body = kwargs["json"]
             json_patch = JsonPatch(request_body)
             modified_netzvertrag_json = netzvertrag_json.copy()
             result = json_patch.apply(modified_netzvertrag_json)


### PR DESCRIPTION
fixes
> Only io.IOBase, multidict and (name, file) pairs allowed, use .add_field() for passing more complex parameters, got ...