### PR TITLE
fix: let `model_validator` return `self`

### DIFF
--- a/src/tmdsclient/client/config.py
+++ b/src/tmdsclient/client/config.py
@@ -89,7 +89,7 @@ class OAuthTmdsConfig(TmdsConfig):
     This is useful when you have ways to get a token but not a client id and secret.
     """
 
-    @model_validator(mode="after")  # type:ignore[misc, no-untyped-def]
+    @model_validator(mode="after")
     def check_secret_or_token_is_present(self) -> Self:  # pylint:disable=no-self-argument
         """
         Ensures that either (id+secret) or a bare token are present


### PR DESCRIPTION
UserWarning: A custom validator is returning a value other than `self`.
Returning anything other than `self` from a top level model validator isn't supported when validating via `__init__`.
See the `model_validator` docs (https://docs.pydantic.dev/latest/concepts/validators/#model-validators) for more details.
